### PR TITLE
minor fix in xtfa's minplus toolbox

### DIFF
--- a/src/saihu/xtfa/minPlusToolbox.py
+++ b/src/saihu/xtfa/minPlusToolbox.py
@@ -470,7 +470,7 @@ class LeakyBucket(Curve):
 
     def __mul__(self, o: Curve) -> Curve:
         if(isinstance(o,NoCurve)):
-            return NoCurve
+            return NoCurve()
         if(isinstance(o,LeakyBucket)):
             return GVBR([copy.deepcopy(self),copy.deepcopy(o)]).simplify()
         if(isinstance(o,GVBR)):


### PR DESCRIPTION
This fixes a bug in xTFA's min-plus toolbox.
The bug does not affect the validity of xTFA's results but leads to exception-throw in some corner-cases.