### PR TITLE
[Draft] Implementation of differentiated service curves for xTFA

### DIFF
--- a/src/saihu/xtfa/networks.py
+++ b/src/saihu/xtfa/networks.py
@@ -203,16 +203,20 @@ class WopanetReader:
                 return edge
         return (None,None)
 
+    def processAsymmetry(node, initial_link_dict):
+        pass
+
     def setComputationnalFlags(self, net: 'FeedForwardNetwork', root: xml.etree.ElementTree.Element):
         for node in net.gif.nodes.keys():
             dic_link_level = net.physicalTopo.edges[self.getPhyEdgeFromName(net, net.gif.nodes[node]["phylink_name"])]
+            updated_dic_link_level = self.processAsymmetry(node, dic_link_level)
             dic_node_level = net.physicalTopo.nodes[net.gif.nodes[node]["phynode_name"]]
             dic_network_level = root.findall("network")[0].attrib
 
             newDic = dict(net.netFlags)
             newDic = dict(newDic, **dic_network_level)
             newDic = dict(newDic, **dic_node_level)
-            newDic = dict(newDic, **dic_link_level)
+            newDic = dict(newDic, **updated_dic_link_level)
             net.gif.nodes[node]["computational_flags"] = dict( (key,newDic[key]) for key in (newDic.keys()))
             
     def configure_network_from_xml(self, net: 'FeedForwardNetwork', xmlFileName: str):


### PR DESCRIPTION
Not ready, ongoing work. Corresponds to step 1 of Issue #8 

After this PR is completed & merged, xTFA will support reading different rate-latency parameters for the two ends of a WopanetXML's bidirectional `link`.

In the XML, if the `link` has an attribute `service-latency`, then this latency is set for the two output ports connected to this bidirectional `link`. Otherwise, the output port of the switch referenced by the attribute `to` [resp. `from`] gets, for the latency, the value indicated in attribute `service-latency-of-to` [resp. `service-latency-of-from`] in the `link`'s properties. If they are not present, no latency is forwarded to xTFA's internals, which should raise an exception during autoconfiguration of the xTFA pipelines.

In the XML, if the `link` has an attribute `service-rate`, then this rate is set for the two output ports connected to this bidirectional `link`. Otherwise, the output port of the switch referenced by the attribute `to` [resp. `from`] gets, for the service rate, the value indicated in attribute `service-latency-of-to` [resp. `service-latency-of-from`] in the `link`'s properties. If they are not present, no rate is forwarded to xTFA's internals, which should raise an exception during autoconfiguration of the xTFA pipelines.

In the XML, if the `link` has an attribute `transmission-capacity`, then this capacity is set for the two output ports connected to this bidirectional `link`. Otherwise, the output port of the switch referenced by the attribute `to` [resp. `from`] gets, for the capacity, the value indicated in attribute `transmission-capacity-of-to` [resp. `transmission-capacity-of-from`] in the `link`'s properties. If they are not present, no rate is forwarded to xTFA's internals, which should *not* raise an exception but it will deactivate all the improvements based on line capacity (input shaping, Mohammadpour et al.'s delay improvement, etc.)

This should guarantee retro-compatibility.

- [ ] Add processing of above optional tags when reading the XML in xTFA
- [ ] Update documentation of XML files
- [ ] Update the JSON-to-XML translator