### PR TITLE
Fix/sfa inconsistent value

### DIFF
--- a/src/saihu/interface.py
+++ b/src/saihu/interface.py
@@ -526,6 +526,11 @@ class TSN_Analyzer:
             flow_paths, flow_cmu_delays = self._xtfa_delay_per_flow(
                 xtfa_net, len(from_converted_file) > 0
             )
+            # skip if obtains nothing
+            if all(len(delay) == 0 for delay in flow_cmu_delays.values()):
+                print("Skip because no result obtained from xTFA, maybe it is because of ARBITRARY multiplexing")
+                return
+
             # determine delay multiplier
             min_mul = unit_util.decide_min_multiplier(server_delays.values())
             if self.serv_delay_mul is None:
@@ -538,7 +543,10 @@ class TSN_Analyzer:
 
             flow_delays = dict()
             for fl_name, cmu_delays in flow_cmu_delays.items():
+                if len(cmu_delays) == 0:
+                    continue
                 flow_delays[fl_name] = cmu_delays[-1]
+
             # determine delay multiplier
             min_mul = unit_util.decide_min_multiplier(flow_delays.values())
             if self.flow_delay_mul is None:
@@ -751,7 +759,7 @@ class TSN_Analyzer:
 
             panco_anzr = panco_analyzer(netfile)
             output_shaping = (
-                self.shaping == FORCE_SHAPER.AUTO or self.shaping == FORCE_SHAPER.ON
+                self.shaping == FORCE_SHAPER.AUTO and panco_anzr.shaper_defined or self.shaping == FORCE_SHAPER.ON
             )
             panco_anzr.build_network(output_shaping)
 

--- a/src/saihu/javapy/NetworkAnalysis/NetworkScriptHandler.java
+++ b/src/saihu/javapy/NetworkAnalysis/NetworkScriptHandler.java
@@ -153,15 +153,13 @@ public class NetworkScriptHandler {
             double lat = latencies.getDouble(0);
             double rate = rates.getDouble(0);
             ServiceCurve sCurve = Curve.getFactory().createRateLatency(rate, lat);
-            // Combine multiple segments, temporarily disabled because it causes trouble while calculating with
-            // PMOO, TMA and LUDB
-//            for (int j=1; j<curveSegmentsNum; j++){
-//                lat = latencies.getDouble(j);
-//                rate = rates.getDouble(j);
-//                ServiceCurve newSegment = Curve.getFactory().createRateLatency(rate, lat);
-//                // Update the curve
-//                sCurve = Curve.getUtils().max(sCurve, newSegment);
-//            }
+            for (int j=1; j<curveSegmentsNum; j++){
+                lat = latencies.getDouble(j);
+                rate = rates.getDouble(j);
+                ServiceCurve newSegment = Curve.getFactory().createRateLatency(rate, lat);
+                // Update the curve
+                sCurve = Curve.getUtils().max(sCurve, newSegment);
+            }
 
             // Construct max service curve
             double maxPacketLength = getMaxPacketLength(i);
@@ -169,7 +167,8 @@ public class NetworkScriptHandler {
             Curve maxCurve = Curve.getFactory().createTokenBucket(capacity, maxPacketLength);
             MaxServiceCurve msCurve = Curve.getFactory().createMaxServiceCurve(maxCurve);
 
-            String multiplexing = serverInfo.optString("multiplexing", "FIFO");
+            String defaultMultiplexing = networkInfo.optString("multiplexing", "ARBITRARY");
+            String multiplexing = serverInfo.optString("multiplexing", defaultMultiplexing);
             AnalysisConfig.Multiplexing localMultiplexing;
             if (multiplexing.equalsIgnoreCase("FIFO")) {
                 localMultiplexing = AnalysisConfig.Multiplexing.FIFO;

--- a/src/saihu/netscript/netdef.py
+++ b/src/saihu/netscript/netdef.py
@@ -514,9 +514,12 @@ class OutputPortNet:
             # Capacity #
             ############
             # Default capacity is the maximum service rate
-            default_capacity = network_def["network"].get("capacity", max(service_curve["rates"]))
+            default_capacity = network_def["network"].get("capacity", None)
             capacity = ser.get("capacity", default_capacity)
-            capacity = try_raise(f"Parsing servers.capacity of \"{ser_name}\"", capacity, self._convert_unit, capacity, unit["rate"], "rate")
+            if capacity is None:
+                capacity = max(service_curve["rates"])
+            else:
+                capacity = try_raise(f"Parsing servers.capacity of \"{ser_name}\"", capacity, self._convert_unit, capacity, unit["rate"], "rate")
 
             # check server capacity validity
             if capacity <= 0:


### PR DESCRIPTION
# Fix inconsistent value for DNC SFA 

## Changes

- Change default multiplexing in DNC file parsing to `Arbitrary` to match the internal setting of DNC when initializing a server.
- Fix sometimes a server capacity's unit is upconverted twice.
- Fix shaping behavior in PANCO. Fix Saihu still wants to apply shaping under AUTO shaping when partial servers do not have capacity defined.