### PR TITLE
Some changes for v2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,9 +317,9 @@ A physical network is defined in `WoPANets` format as a `.xml` file. It contains
         For technical details on `xTFA` options please contact the author of `xTFA` [Ludovic Thomas](mailto:ludovic.thomas@cnrs.fr).
     - Other attributes are optional, but used as a global parameter. 
     
-    Note: `WoPANets XML` and `xTFA` use a inheritance scheme of the attributes. Each output port of the network inherits from the attributes of the `link` to which it is connected, from the attributes of the `station`/`switch` to which it belongs, and from the attributes of the `network`, with a priority scheme `link` > `switch`/`station` > `network`. This means that an attribute set for a `link` overwrites any attribute of the same name set for the associated `station`/`switch`, which overwites in turn any attribute of the same name set for the `network`.
+    Note: `WoPANets XML` and `xTFA` use a inheritance scheme of the attributes. Each output port of the network inherits from the attributes of the `link` to which it is connected, from the attributes of the `station`/`switch` to which it belongs, and from the attributes of the `network`. Conflicts (attributes with the same name) are resolved with the following priority scheme: `link` > `switch`/`station` > `network`. This means that an attribute set for a `link` overwrites any attribute of the same name set for the associated `station`/`switch`, which overwites in turn any attribute of the same name set for the `network`.
 
-    For example, `transmission-capacity` can be set as an attribute of the `network` and will be inherited by all output ports of the network, except if you overwrite it with a `transmission-capacity` attribute at a given `link`.
+    For example, `transmission-capacity` can be set as an attribute of the `network` and will be inherited by all output ports of the network, except if you overwrite it with a `transmission-capacity` attribute at a given `link` or `switch`/`station`.
     Reciproqually, you can overwrite the technology of one specific `switch` by defining an attribute `technology` local to a `switch`. It will overwrite the `technology` attribute defined inside the `network` element for all the output ports connected to this switch and their models will be subsequently adapted. 
     
 
@@ -339,13 +339,13 @@ A physical network is defined in `WoPANets` format as a `.xml` file. It contains
     ```
 - `link`: **Bidirectional** link between two stations or switches, has the following attributes
     - `name`: Name of link.
-    - `from`: Name of the first station/switch connected to the link. Need to be name of station/switch.
-    - `to`: Name of the first station/switch connected to the link. Need to be name of station/switch.
-    - `fromPort`: A port number or any string to differentiates the port of the first (ie, `from`) station/switch connected to this link from any other port of the same station/switch connected to other links.
-    - `toPort`: A port number or any string to differentiates the port of the second (ie, `to`) station/switch connected to this link from any other port of the same station/switch connected to other links.
+    - `from`: Name of the first station/switch connected to the link. Needs to be the name of a station/switch.
+    - `to`: Name of the first station/switch connected to the link. Needs to be the name of a station/switch.
+    - `fromPort`: A port number or any string to differentiate the port of the first (ie, `from`) station/switch connected to this link from any other port of the same station/switch connected to other links.
+    - `toPort`: A port number or any string to differentiate the port of the second (ie, `to`) station/switch connected to this link from any other port of the same station/switch connected to other links.
     - `transmission-capacity`: The transmission capacity of the link. Can assign different rate units, `Mbps`... (But not `bps` alone)
 
-    Note: The `to`/`from` distinction is only cosmetic. Both stations play the same role in the connection. In `Wopanet XML`, each `link` is **bidirectional**.
+    Note: The `to`/`from` distinction is only cosmetic. Both ends of the link play the same role in the connection. In `Wopanet XML`, each `link` is **bidirectional**.
 
     Example:
     ```xml
@@ -355,7 +355,7 @@ A physical network is defined in `WoPANets` format as a `.xml` file. It contains
     Note: You may also set the `service-rate`, `service-latency` or `transmission-capacity` attributes as attributes of the `link` element. Due to the inheritance principle, they will overwrite any identical attribute set for the `switch`/`station` or `network`.
     But because of the bidirectional property of the link, the property will be applied to both output ports on both side of the link.
 
-    To set an attribute `<my-attribute>` only for the output port connected on the "`from`" `switch` [resp. on the "`to`" `switch`], you can use the attribute `<my-attribute>-of-from` [resp `<my-attribute>-of-to`].
+    To set an attribute `<my-attribute>` only for the output port of the "`from`" `switch` [resp. on the "`to`" `switch`], you can use the attribute `<my-attribute>-of-from` [resp `<my-attribute>-of-to`].
     `<my-attribute>-of-from` then overwrites the attribute `<my-attribute>` if present. 
 
 
@@ -367,7 +367,7 @@ A physical network is defined in `WoPANets` format as a `.xml` file. It contains
     <link from="ES1" to="ES2" fromPort="0" toPort="0" service-rate-of-from="1Gbps" service-rate="100Mbps" />
     ```
 
-    In `NetA`, the output port `ES1-0` has a service rate of 1Gbps (`service-rate-of-from` has priority) whereas the output port `ES2-0` has a service rate of 100Mbps (`service-rate-of-to` is absent, we fall back to the `service-rate` attribute).
+    In `NetA`, the output port `ES1-0` has a service rate of 1Gbps (`service-rate-of-from` has priority over the `service-rate` attribute), whereas the output port `ES2-0` has a service rate of 100Mbps (`service-rate-of-to` is absent, we fall back to the `service-rate` attribute).
 
     Example B:
     ```xml

--- a/src/saihu/xtfa/networks.py
+++ b/src/saihu/xtfa/networks.py
@@ -203,16 +203,20 @@ class WopanetReader:
                 return edge
         return (None,None)
 
+    def processAsymmetry(node, initial_link_dict):
+        pass
+
     def setComputationnalFlags(self, net: 'FeedForwardNetwork', root: xml.etree.ElementTree.Element):
         for node in net.gif.nodes.keys():
             dic_link_level = net.physicalTopo.edges[self.getPhyEdgeFromName(net, net.gif.nodes[node]["phylink_name"])]
+            updated_dic_link_level = self.processAsymmetry(node, dic_link_level)
             dic_node_level = net.physicalTopo.nodes[net.gif.nodes[node]["phynode_name"]]
             dic_network_level = root.findall("network")[0].attrib
 
             newDic = dict(net.netFlags)
             newDic = dict(newDic, **dic_network_level)
             newDic = dict(newDic, **dic_node_level)
-            newDic = dict(newDic, **dic_link_level)
+            newDic = dict(newDic, **updated_dic_link_level)
             net.gif.nodes[node]["computational_flags"] = dict( (key,newDic[key]) for key in (newDic.keys()))
             
     def configure_network_from_xml(self, net: 'FeedForwardNetwork', xmlFileName: str):

--- a/src/saihu/xtfa/networks.py
+++ b/src/saihu/xtfa/networks.py
@@ -218,17 +218,24 @@ class WopanetReader:
         """
         updated_dict = dict(link_dict)
         this_one = None
+        the_other = None
         if updated_dict["to"] == physical_node:
             this_one = "to"
+            the_other = "from"
         if updated_dict["from"] == physical_node:
             this_one = "from"
+            the_other = "to"
         assert this_one != None
+        assert the_other != None
         
-        for key in updated_dict.keys():
+        list_of_keys = list(updated_dict.keys())
+        for key in list_of_keys:
             assert isinstance(key, str)
             if key.endswith("-of-%s" % this_one):
                 attribute = key.removesuffix("-of-%s" % this_one)
                 updated_dict[attribute] = updated_dict.pop(key)
+            if key.endswith("-of-%s" % the_other):
+                updated_dict.pop(key, None)
         return updated_dict
     
     def setComputationnalFlags(self, net: 'FeedForwardNetwork', root: xml.etree.ElementTree.Element):
@@ -499,7 +506,6 @@ class FeedForwardNetwork(NetworkInterface):
             n = nodes.Node(nodeName, self.name)
             self.gif.nodes[nodeName]["model"] = n
             n.autoInstallPipelines(self.gif.nodes[nodeName]["computational_flags"], self)
-        pass
 
     def isNodeReadyForComputation(self, nodeName):
         if not self.gif.in_edges(nodeName):

--- a/src/saihu/xtfa/networks.py
+++ b/src/saihu/xtfa/networks.py
@@ -204,15 +204,17 @@ class WopanetReader:
         return (None,None)
 
     def processAsymmetry(self, node, physical_node, link_dict: Mapping) -> Mapping:
-        """Modifies link_dict to process the optional attributes that are used to describe a difference service latency and service rate and link capacity fo the two ends of a same link.
-            If "service-rate" is not already present in link_dict's keys, updated_dict["service-rate"] gets the value of link_dict["service-rate-of-to"] or link_dict["service-rate-of-from"] (depending on the role of the physical node for the link).
-            If neither service-rate, nor service-rate-of-to, nor service-rate-of-from is present in link_dict's keys, then no "service-rate" key is added to updated_dict
+        """ Return a modified copy of link_dict, where any attribute <attribute>-of-<to/from>=<value>
+        is modified as <attribute>=<value>, by overwritting <attribute> if it was already present. 
+
         Args:
-            node (): The node (output-port)
-            physical_node (): The physical node (switch)
-            link_dict (Mapping): The dictionnary of link attributes
-        Return:
-            The updated dictionnary (modified copy of the input)
+            node (str): The output port 
+            physical_node (str): The physical node on which the output port is connected
+            link_dict (Mapping): List of computationnal flags that derives from the inheritance network/switch/link
+            
+
+        Returns:
+            Mapping: The modified mapping
         """
         updated_dict = dict(link_dict)
         this_one = None
@@ -221,26 +223,12 @@ class WopanetReader:
         if updated_dict["from"] == physical_node:
             this_one = "from"
         assert this_one != None
-        if "service-latency" not in updated_dict.keys():
-            latency = updated_dict.get("service-latency-of-%s" % this_one, None)
-            if latency != None:
-                updated_dict["service-latency"] = latency
-        if "service-rate" not in updated_dict.keys():
-            rate = updated_dict.get("service-rate-of-%s" % this_one, None)
-            if rate != None:
-                updated_dict["service-rate"] = rate
-        if "transmission-capacity" not in updated_dict.keys():
-            capacity = updated_dict.get("transmission-capacity-of-%s" % this_one, None)
-            if capacity != None:
-                updated_dict["transmission-capacity"] = capacity
-        #Cleaning options
-        updated_dict.pop("service-latency-of-from", None)
-        updated_dict.pop("service-latency-of-to", None)
-        updated_dict.pop("service-rate-of-from", None)
-        updated_dict.pop("service-rate-of-to", None)
-        updated_dict.pop("transmission-capacity-of-from", None)
-        updated_dict.pop("transmission-capacity-of-to", None)
-            
+        
+        for key in updated_dict.keys():
+            assert isinstance(key, str)
+            if key.endswith("-of-%s" % this_one):
+                attribute = key.removesuffix("-of-%s" % this_one)
+                updated_dict[attribute] = updated_dict.pop(key)
         return updated_dict
     
     def setComputationnalFlags(self, net: 'FeedForwardNetwork', root: xml.etree.ElementTree.Element):


### PR DESCRIPTION
Hi, this PR is just to track some of the changes I plan to do for a "v2025":

- [ ] Make xTFA read JSON directly, without an XML / JSON translator
- [ ]  Change the multicast definition to either a "path" with a single path OR "paths" with a list of paths (support both, "paths" overwrites "path" if both are present)
- [ ] Add support for FIFO-per-class networks to xTFA
- [ ] Add computation of class-level left-over service curves in xTFA for:
    - [ ] NP-SP
    - [ ] CBS
- [ ] Add support of CBS shaping curves to xTFA
- [ ] Change ATS support in xTFA to support a wider variety of ATS configurations (from ATS Sched per flow to ATS Sched per group)
- [ ] Deprecate XMLs
- [ ] Update translators to other tools
- [ ] xTFA naming conventions, linter, etc
- [ ] xTFA Sphinx doc